### PR TITLE
Fix issue #780.

### DIFF
--- a/samex-naif/cls/Generator.c
+++ b/samex-naif/cls/Generator.c
@@ -119,7 +119,6 @@ FUNC_IMPL_1_opt(Generator_stdForEach, generator, function) {
         zstackPointer save = datFrameStart();
         zvalue nextGen = METH_CALL(cm_fetch(gen), nextValue, box);
         cm_store(gen, nextGen);
-        datFrameReturn(save, NULL);
 
         if (nextGen == NULL) {
             break;
@@ -133,6 +132,8 @@ FUNC_IMPL_1_opt(Generator_stdForEach, generator, function) {
                 cm_store(result, v);
             }
         }
+
+        datFrameReturn(save, NULL);
     }
 
     return cm_fetch(result);

--- a/samex-naif/dat/frame.c
+++ b/samex-naif/dat/frame.c
@@ -60,3 +60,6 @@ extern zvalue datFrameAdd(zvalue value);
 
 // Documented in header.
 extern void datFrameReturn(zstackPointer savedStack, zvalue returnValue);
+
+// Documented in header.
+extern void datFrameReturn2(zstackPointer savedStack, zvalue r1, zvalue r2);


### PR DESCRIPTION
This reworks how the generic implementations of `collect` and `forEach` spew onto the value stack. In particular, they now spew less.

The price is that these methods now run slower, as they're making calls to store and fetch cell contents that they didn't have to do before. Should it turn out to matter, this can be optimized a bit, probably to the point of having the previous level of performance.